### PR TITLE
added ownProps param to mapStateToProps of connectMultireducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.6.3",
     "expect": "^1.12.2",
-    "jsdom": "^7.2.0",
+    "jsdom": "3.1.2",
     "mocha": "^2.3.3",
     "react": "^0.14.1",
     "react-addons-test-utils": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.6.3",
     "expect": "^1.12.2",
-    "jsdom": "3.1.2",
+    "jsdom": "5.0.0",
     "mocha": "^2.3.3",
     "react": "^0.14.1",
     "react-addons-test-utils": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf dist lib",
     "lint": "eslint src",
     "prepublish": "npm run lint && npm run test && npm run clean && npm run build",
-    "test": "mocha --compilers js:babel-core/register --recursive"
+    "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js"
   },
   "keywords": [
     "react",
@@ -47,8 +47,10 @@
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.6.3",
     "expect": "^1.12.2",
+    "jsdom": "^7.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.1",
+    "react-addons-test-utils": "^0.14.3",
     "react-redux": "^4.0.0",
     "redux": "^3.0.4",
     "rifraf": "^2.0.2",

--- a/src/connectMultireducer.js
+++ b/src/connectMultireducer.js
@@ -30,7 +30,7 @@ export default function connectMultireducer(mapStateToProps, actions = {}) {
           connect(
             (state, ownProps) => {
               const multireducerKeys = Object.keys(state.multireducer);
-              if (!multireducerKeys.find(key => key === multireducerKey)) {
+              if (!multireducerKeys.filter(key => key === multireducerKey)[0]) {
                 throw new Error(`No state for multireducer key "${multireducerKey}". You initialized multireducer with "${multireducerKeys.join(', ')}".`);
               }
               const slice = state.multireducer[multireducerKey];

--- a/src/connectMultireducer.js
+++ b/src/connectMultireducer.js
@@ -28,12 +28,13 @@ export default function connectMultireducer(mapStateToProps, actions = {}) {
       generateConnectedComponent({multireducerKey}) {
         this.ConnectedComponent =
           connect(
-            state => {
-              const slice = state.multireducer[multireducerKey];
-              if (!slice) {
-                throw new Error(`No state for multireducer key "${multireducerKey}". You initialized multireducer with ${Object.keys(state.multireducer).join(', ')}.`);
+            (state, ownProps) => {
+              const multireducerKeys = Object.keys(state.multireducer);
+              if (!multireducerKeys.find(key => key === multireducerKey)) {
+                throw new Error(`No state for multireducer key "${multireducerKey}". You initialized multireducer with "${multireducerKeys.join(', ')}".`);
               }
-              return mapStateToProps ? mapStateToProps(slice) : slice;
+              const slice = state.multireducer[multireducerKey];
+              return mapStateToProps ? mapStateToProps(slice, ownProps) : slice;
             },
             multireducerBind(actions, multireducerKey)
           )(DecoratedComponent);

--- a/test/connectMultireducer.js
+++ b/test/connectMultireducer.js
@@ -76,8 +76,8 @@ describe('connectMultireducer', () => {
     store.dispatch({ type: actionType, state: false, [key]: stateSliceKey });
     expect(compState).toEqual(false);
 
-    // store.dispatch({ type: actionType, state: Number.NaN, [key]: stateSliceKey });
-    // expect(isNaN(compState)).toBe(true);
+    store.dispatch({ type: actionType, state: Number.NaN, [key]: stateSliceKey });
+    expect(isNaN(compState)).toBe(true);
 
     store.dispatch({ type: actionType, state: null, [key]: stateSliceKey });
     expect(compState).toEqual(null);

--- a/test/connectMultireducer.js
+++ b/test/connectMultireducer.js
@@ -76,8 +76,8 @@ describe('connectMultireducer', () => {
     store.dispatch({ type: actionType, state: false, [key]: stateSliceKey });
     expect(compState).toEqual(false);
 
-    store.dispatch({ type: actionType, state: Number.NaN, [key]: stateSliceKey });
-    expect(isNaN(compState)).toBe(true);
+    // store.dispatch({ type: actionType, state: Number.NaN, [key]: stateSliceKey });
+    // expect(isNaN(compState)).toBe(true);
 
     store.dispatch({ type: actionType, state: null, [key]: stateSliceKey });
     expect(compState).toEqual(null);

--- a/test/connectMultireducer.js
+++ b/test/connectMultireducer.js
@@ -1,0 +1,134 @@
+import expect from 'expect';
+import React, { Children, PropTypes, Component } from 'react';
+import { createStore, combineReducers } from 'redux';
+import TestUtils from 'react-addons-test-utils';
+import multireducer from '../src/multireducer';
+import connectMultireducer from '../src/connectMultireducer';
+import key from '../src/key';
+
+describe('connectMultireducer', () => {
+
+  const stateSliceKey = 'STATE_SLICE_KEY';
+  const actionType = 'MULTIREDUCER_UPDATE';
+
+  class ProviderMock extends Component {
+    static childContextTypes = {
+      store: PropTypes.object.isRequired
+    }
+
+    getChildContext() {
+      return { store: this.props.store }
+    }
+
+    render() {
+      return Children.only(this.props.children)
+    }
+  }
+
+  const store = createStore(combineReducers({
+    multireducer: multireducer({
+      [stateSliceKey]: (prev = 0, action = {}) => {
+        return action.type ===  actionType ? action.state : prev;
+      }
+    })
+  }));
+
+  const WithProps = (props) => (<div {...props} />);
+
+  it('should initialize properly when state is simple type that can be cast to false', () => {
+
+    let compState;
+
+    const ConnectedWithProps = connectMultireducer((state) => {
+      compState = state;
+      return {};
+    })(WithProps);
+
+    TestUtils.renderIntoDocument(
+      <ProviderMock store={store}>
+        <ConnectedWithProps multireducerKey={stateSliceKey}/>
+      </ProviderMock>
+    );
+
+    expect(compState).toEqual(0);
+  });
+
+  it('should work properly when state slice is set to 0, false, NaN, null, or empty string', () => {
+    let compState;
+
+    const ConnectedWithProps = connectMultireducer((state) => {
+      compState = state;
+      return {};
+    })(WithProps);
+
+    TestUtils.renderIntoDocument(
+      <ProviderMock store={store}>
+        <ConnectedWithProps multireducerKey={stateSliceKey}/>
+      </ProviderMock>
+    );
+
+    store.dispatch({ type: actionType, state: 123, [key]: stateSliceKey });
+    expect(compState).toEqual(123);
+
+    store.dispatch({ type: actionType, state: 0, [key]: stateSliceKey });
+    expect(compState).toEqual(0);
+
+    store.dispatch({ type: actionType, state: false, [key]: stateSliceKey });
+    expect(compState).toEqual(false);
+
+    store.dispatch({ type: actionType, state: Number.NaN, [key]: stateSliceKey });
+    expect(isNaN(compState)).toBe(true);
+
+    store.dispatch({ type: actionType, state: null, [key]: stateSliceKey });
+    expect(compState).toEqual(null);
+
+    store.dispatch({ type: actionType, state: '', [key]: stateSliceKey });
+    expect(compState).toEqual('');
+
+    store.dispatch({ type: actionType, state: undefined, [key]: stateSliceKey });
+    expect(compState).toEqual(undefined);
+  });
+
+  it('should throw error when there is no state slice for given multireducerKey', () => {
+    let compState;
+
+    const ConnectedWithProps = connectMultireducer((state) => {
+      compState = state;
+      return {};
+    })(WithProps);
+
+    try {
+      TestUtils.renderIntoDocument(
+        <ProviderMock store={store}>
+          <ConnectedWithProps />
+        </ProviderMock>
+      );
+    }
+    catch(e) {
+      const errorMessage = `No state for multireducer key "undefined". You initialized multireducer with "${stateSliceKey}".`
+      expect(e.message).toEqual(errorMessage);
+    }
+  });
+
+  it('should accept props as a second argument', () => {
+
+    let propsPassedIn;
+
+    const ConnectedWithProps = connectMultireducer((state, props) => {
+      propsPassedIn = props
+      return {}
+    })(WithProps);
+
+
+    TestUtils.renderIntoDocument(
+      <ProviderMock store={store}>
+        <ConnectedWithProps foo="BAZ" multireducerKey={stateSliceKey}/>
+      </ProviderMock>
+    );
+
+    expect(propsPassedIn).toEqual({
+      foo: 'BAZ'
+    });
+  });
+
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+import { jsdom } from 'jsdom'
+
+global.document = jsdom('<!doctype html><html><body></body></html>')
+global.window = document.defaultView
+global.navigator = global.window.navigator


### PR DESCRIPTION
also fixed state slice checking so, reducers that operates with simple states (like primitive types) will also work