### PR TITLE
Add support for redux-thunk with extra argument

### DIFF
--- a/src/wrapDispatch.js
+++ b/src/wrapDispatch.js
@@ -4,8 +4,8 @@ export default function wrapDispatch(dispatch, reducerKey) {
   const wrappedDispatch = (action) => {
     let wrappedAction;
     if (typeof action === 'function') {
-      wrappedAction = (globalDispatch, getState) =>
-        action(wrappedDispatch, getState, globalDispatch, reducerKey);
+      wrappedAction = (globalDispatch, getState, extraArgument) =>
+        action(wrappedDispatch, getState, extraArgument, globalDispatch, reducerKey);
     } else if (typeof action === 'object') {
       wrappedAction = wrapAction(action, reducerKey);
     }


### PR DESCRIPTION
Hello,

Redux-thunk can be used with third argument in actions and it would be really nice if multireducer would support this too. Right now this argument lost in wrapDispatch function.