### PR TITLE
Add support for redux-thunk with extra argument

### DIFF
--- a/src/wrapDispatch.js
+++ b/src/wrapDispatch.js
@@ -4,8 +4,8 @@ export default function wrapDispatch(dispatch, reducerKey) {
   const wrappedDispatch = (action) => {
     let wrappedAction;
     if (typeof action === 'function') {
-      wrappedAction = (globalDispatch, getState) =>
-        action(wrappedDispatch, getState, globalDispatch, reducerKey);
+      wrappedAction = (globalDispatch, getState, extraArgument) =>
+        action(wrappedDispatch, getState, globalDispatch, reducerKey, extraArgument);
     } else if (typeof action === 'object') {
       wrappedAction = wrapAction(action, reducerKey);
     }

--- a/test/wrapDispatch.spec.js
+++ b/test/wrapDispatch.spec.js
@@ -16,7 +16,8 @@ describe('wrapDispatch', () => {
 
   it('dispatch thunk action', () => {
     const getState = () => {};
-    const dispatch = createSpy().andCall(action => action(dispatch, getState));
+    const extraArgument = {};
+    const dispatch = createSpy().andCall(action => action(dispatch, getState, extraArgument));
     const action = createSpy();
     const wrappedDispatch = wrapDispatch(dispatch, 'additional');
     wrappedDispatch(action);
@@ -28,7 +29,8 @@ describe('wrapDispatch', () => {
       wrappedDispatch,
       getState,
       dispatch,
-      'additional'
+      'additional',
+      extraArgument
     ]);
   });
 });


### PR DESCRIPTION
Hello

Redux-thunk can be used with third argument in actions and it would be really nice if multireducer would support this too. Right now this argument lost in wrapDispatch function.
I'm using this changes in my project and it works fine.