### PR TITLE
Remove immutable from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "webpack": "^1.12.12"
   },
   "peerDependencies": {
-    "immutable": "^3.0.0",
     "redux": "^3.0.0"
   },
   "npmName": "multireducer",


### PR DESCRIPTION
Immutable is optional, so it should not be in peerDependencies. This causes a warning with yarn (v1.3.2).